### PR TITLE
Fix isAttachment that did not properly take in consideration disposit…

### DIFF
--- a/src/Part.php
+++ b/src/Part.php
@@ -301,7 +301,7 @@ class Part {
     public function isAttachment(){
         $valid_disposition = in_array(strtolower($this->disposition), ClientManager::get('options.dispositions'));
 
-        if ($this->type == IMAP::MESSAGE_TYPE_TEXT && ($this->ifdisposition == 0 || (empty($this->disposition))) && !$valid_disposition) {
+        if ($this->type == IMAP::MESSAGE_TYPE_TEXT && ($this->ifdisposition == 0 || empty($this->disposition) || !$valid_disposition)) {
             if (($this->subtype == null || in_array((strtolower($this->subtype)), ["plain", "html"])) && $this->filename == null && $this->name == null) {
                 return false;
             }


### PR DESCRIPTION
Resolution of this bug is inspired by https://github.com/Webklex/php-imap/issues/58#issuecomment-747500120 which seems to be the working version that used to exists before $valid_disposition variable was introduced.

This made email part that declare a disposition 'inline' to be considered as attachments even if the config is options['dispositions'] = ['attachment'] (see related issue https://github.com/Webklex/php-imap/issues/193)
